### PR TITLE
support video type `480p.mp4`

### DIFF
--- a/resources/lib/globals.py
+++ b/resources/lib/globals.py
@@ -128,7 +128,7 @@ def get_stream(id):
 
     for stream in json_source['MediaURLs']:
         # if 'AppleTV' in stream['Type']:
-        if '480p_1mbps.mp4' in stream['Type']:
+        if any(t in stream['Type'] for t in ['480p_1mbps.mp4','480p.mp4']):
             stream_url = stream['Path']
             # stream_url = stream_url[0:stream_url.index('.m3u8')]+'.m3u8'
             break


### PR DESCRIPTION
This is in addition to the `480p_1mbps.mp4` type that was already supported.

Videos which were consistently not playing now play. Fixes #4 . 