### PR TITLE
Fixes

### DIFF
--- a/resources/lib/globals.py
+++ b/resources/lib/globals.py
@@ -55,17 +55,21 @@ def list_movies(genre_id):
 
         add_stream(title,url,'movies',icon,fanart,info)
 
+    xbmcplugin.addSortMethod(addon_handle, xbmcplugin.SORT_METHOD_LABEL)
+    xbmcplugin.addSortMethod(addon_handle, xbmcplugin.SORT_METHOD_LABEL_IGNORE_THE)
+
 
 def list_genre(id):
     url = '/genres/%s/all/US?format=json' % id
     json_source = json_request(url)
-    items = sorted(json_source['Items'], key=lambda k: k['Name'].lower(), reverse=False)
-    for genre in items:
+    for genre in json_source['Items']:
         title = genre['Name']
 
         add_dir(title, id, 100, ICON, genre_id=genre['ID'])
         # add_dir(name, id, mode, icon, fanart=None, info=None, genre_id=None)
 
+    xbmcplugin.addSortMethod(addon_handle, xbmcplugin.SORT_METHOD_LABEL)
+    xbmcplugin.addSortMethod(addon_handle, xbmcplugin.SORT_METHOD_LABEL_IGNORE_THE)
 
 def list_shows(genre_id):
     url = '/browse/shows/full/%s/alpha-asc/US/1000/1?format=json' % genre_id
@@ -90,6 +94,9 @@ def list_shows(genre_id):
                 }
 
         add_dir(title,url,102,icon,fanart,info,content_type='tvshows')
+
+    xbmcplugin.addSortMethod(addon_handle, xbmcplugin.SORT_METHOD_LABEL)
+    xbmcplugin.addSortMethod(addon_handle, xbmcplugin.SORT_METHOD_LABEL_IGNORE_THE)
 
 
 def get_episodes(channel):
@@ -116,6 +123,9 @@ def get_episodes(channel):
                 }
 
         add_stream(title,id,'tvshows',icon,fanart,info)
+
+    xbmcplugin.addSortMethod(addon_handle, xbmcplugin.SORT_METHOD_LABEL)
+    xbmcplugin.addSortMethod(addon_handle, xbmcplugin.SORT_METHOD_LABEL_IGNORE_THE)
 
 
 def get_movie_id(channel):

--- a/resources/lib/globals.py
+++ b/resources/lib/globals.py
@@ -82,7 +82,9 @@ def list_shows(genre_id):
         title = show['Title']
         url = str(show['ID'])
         icon = show['ChannelArtTileLarge']
-        fanart = show['Images']['Img_1920x1080']
+        fanart = show['Images']['Img_TTU_1280x720']
+        if fanart == "":
+            fanart = show['Images']['Img_1920x1080']
         info = {'plot':show['Description'],
                 'genre':show['Genre'],
                 'year':show['ReleaseYear'],

--- a/resources/lib/globals.py
+++ b/resources/lib/globals.py
@@ -71,6 +71,7 @@ def list_genre(id):
     xbmcplugin.addSortMethod(addon_handle, xbmcplugin.SORT_METHOD_LABEL)
     xbmcplugin.addSortMethod(addon_handle, xbmcplugin.SORT_METHOD_LABEL_IGNORE_THE)
 
+
 def list_shows(genre_id):
     url = '/browse/shows/full/%s/alpha-asc/US/1000/1?format=json' % genre_id
     # url += '?pageSize=500'


### PR DESCRIPTION
- Better way to sort list items by using Kodi's built-in sorting method.
  Now, user will be able to sort list items in A-Z or Z-A order by selecting 'Order' in the side menu.
  By default, list items are sorted in A-Z order.
- Use correct fanart image (that looks different from poster image) for TV shows.